### PR TITLE
Enable Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: node_js
+node_js:
+  - "node"
+  - "7"
+
+script:
+  - npm run lint
+  - npm test

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "test": "mocha --reporter spec",
     "start": "node lib/xunion.js",
-    "dev": "nodemon lib/xunion.js"
+    "dev": "nodemon lib/xunion.js",
+    "lint": "./node_modules/.bin/eslint . ./**/*.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This is a basic travis config to run linting and our tests (once they exist). It's configured to test node v7, which is the lowest version to support await/async, as well as the latest stable version.