### PR TITLE
Logging error objects

### DIFF
--- a/lib/Logger.js
+++ b/lib/Logger.js
@@ -36,8 +36,17 @@ class Logger {
     this.logger.log(level, msg);
   }
 
-  error(msg) {
-    this.log(Logger.levelsVal[Logger.levels.ERROR], msg);
+  error(msg, err) {
+    let errMsg;
+    if (typeof msg === 'object') {
+      // treat msg as an error object
+      errMsg = msg.stack;
+    } else if (err) {
+      errMsg = `${msg} ${err.stack}`;
+    } else {
+      errMsg = msg;
+    }
+    this.log(Logger.levelsVal[Logger.levels.ERROR], errMsg);
   }
 
   warn(msg) {


### PR DESCRIPTION
This change allows error objects to be logged with full stack trace. The `error()` function now accepts either a custom message and an error or just an error as parameters.